### PR TITLE
Go to readyState DONE when there's a connection error.

### DIFF
--- a/src/xhr.coretcpsocket.js
+++ b/src/xhr.coretcpsocket.js
@@ -269,6 +269,9 @@ var TcpXhr = function () {
             },
 
             set: function (value) {
+                if (this.props.readyState === value) {
+                    return;
+                }
                 this.props.readyState = value;
 
                 this.dispatchEvent('readystatechange');
@@ -636,6 +639,7 @@ TcpXhr.prototype.onDisconnect = function () {
     this.dispatchProgressEvent('error');
     this.processResponse(false);  // Indicate failure (incomplete response)
   }
+  this.readyState = this.DONE;
 };
 
 /**
@@ -1055,6 +1059,7 @@ TcpXhr.prototype.disconnect = function () {
         socketFactory.release(this.socket);
         this.socket = null;
     }
+    this.readyState = this.DONE;
 };
 
 TcpXhr.prototype.expireTimer = function () {

--- a/src/xhr.corexhr.js
+++ b/src/xhr.corexhr.js
@@ -134,7 +134,6 @@ XhrShim.prototype.refresh_ = function() {
       if (!response) {
         this.response = response;
       } else if ('buffer' in response) {
-        this.log_('XhrShim got response buffer: ' + bufferToString(response.buffer));
         this.response = response.buffer;
       } else if ('object' in response) {
         this.response = response.object;
@@ -224,7 +223,7 @@ Object.defineProperty(XhrShim.prototype, 'withCredentials', {
 });
 
 XhrShim.prototype.send = function(data) {
-  this.log_('XhrShim::send(' + data + ')');
+  this.log_('XhrShim::send(...)');
   if (this.readyState !== this.OPENED) {
     // TODO: Should be InvalidStateError
     throw new Error('XhrShim: cannot send in state ' + this.readyState);
@@ -330,7 +329,6 @@ Object.defineProperty(XhrShim.prototype, 'responseText', {
       // TODO: Should be InvalidStateError
       throw new Error('XhrShim: no responseText for type ' + this.responseType_);
     }
-    this.log_('XhrShim returning responseText ' + this.response);
     return this.response;
   }
 });

--- a/test/demo.json
+++ b/test/demo.json
@@ -23,7 +23,8 @@
       "testArrayBufferPost": { "type": "method", "value": [], "ret": "string", "err": "string" },
       "testDomainFronting": { "type": "method", "value": [], "ret": "string", "err": "string" },
       "testFrontDomain": { "type": "method", "value": [], "ret": "string", "err": "string" },
-      "testChunkedEncoding": { "type": "method", "value": [], "ret": "string", "err": "string" }
+      "testChunkedEncoding": { "type": "method", "value": [], "ret": "string", "err": "string" },
+      "testTlsErrorEvent": { "type": "method", "value": [], "ret": "string", "err": "string" }
     }
   },
   "permissions": [

--- a/test/integration.js
+++ b/test/integration.js
@@ -130,4 +130,8 @@ describe('Basic XMLHttpRequest integration tests', function() {
   it('coretcpsocket: chunked encoding', function(done) {
     runTest(done, 'coretcpsocket', 'testChunkedEncoding');
   });
+
+  it('corexhr: tls error event', function(done) {
+    runTest(done, 'corexhr', 'testTlsErrorEvent');
+  });
 });


### PR DESCRIPTION
This brings xhr.coretcpsocket in line with browser behavior.
It's also necessary for socket.io, which uses this state
change to detect errors early (in engine.io-client's polling-xhr.js)
instead of waiting and timing out.

This change also includes some reduction of extremely verbose
logging, and an additional test for TLS connection failures.
